### PR TITLE
Add option exim4_ignore_smtp_line_length_limit.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,4 @@ exim_certificate_ca_path: /etc/ssl/local/certs/exim_relay.bundle.crt
 exim4_smarthost_relay_hashes: []
 exim4_smarthost_relay_for: []
 exim4_email_addresses: []
+exim4_ignore_smtp_line_length_limit: false

--- a/templates/localmacros.j2
+++ b/templates/localmacros.j2
@@ -41,3 +41,7 @@ REMOTE_SMTP_SMARTHOST_TLS_CERTIFICATE = {{ exim_certificate_path }}
 REMOTE_SMTP_SMARTHOST_PRIVATEKEY = {{ exim_certificate_key_path }}
 REMOTE_SMTP_SMARTHOST_HOSTS_REQUIRE_TLS = *
 {% endif %}
+
+{% if exim4_ignore_smtp_line_length_limit %}
+IGNORE_SMTP_LINE_LENGTH_LIMIT = true
+{% endif %}


### PR DESCRIPTION
It allows configuring IGNORE_SMTP_LINE_LENGTH_LIMIT.