### PR TITLE
Install certificates after exim is installed

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -116,12 +116,4 @@ galaxy_info:
   #- packaging
   #- system
   #- web
-dependencies:
-  - role: ajsalminen.ssl_certificate
-    ssl_certificate_key_common_name: exim_relay
-    ssl_certificate_assets_path: "{{ PLAYBOOK_PRIVATE_ROLE_ASSETS_PATH }}ssl_certificate/{{ inventory_hostname }}"
-    ssl_certificate_ca_subject: "/CN=kifi-ca"
-    ssl_certificate_subject: "/CN={{ inventory_hostname }}"
-    ssl_certificate_group: Debian-exim
-    when: exim4_is_smarthost or exim4_use_client_certificates
-    tags: ssl
+dependencies: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,6 +8,18 @@
       - exim4
       - heirloom-mailx
 
+- name: Install ssl certificates
+  include_role:
+    name: ajsalminen.ssl_certificate
+  vars:
+    ssl_certificate_key_common_name: exim_relay
+    ssl_certificate_assets_path: "{{ PLAYBOOK_PRIVATE_ROLE_ASSETS_PATH }}ssl_certificate/{{ inventory_hostname }}"
+    ssl_certificate_ca_subject: "/CN=kifi-ca"
+    ssl_certificate_subject: "/CN={{ inventory_hostname }}"
+    ssl_certificate_group: Debian-exim
+    when: exim4_is_smarthost or exim4_use_client_certificates
+  tags: ssl
+
 - include: dkim.yml
   when: exim4_enable_dkim
 - include: generic.yml


### PR DESCRIPTION
ssl_certificate_group: Debian-exim can't be used before exim is
installed as the group does not exist yet.