### PR TITLE
Add option exim4_partial_smarthost_percentage

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,3 +28,4 @@ exim4_smarthost_relay_hashes: []
 exim4_smarthost_relay_for: []
 exim4_email_addresses: []
 exim4_ignore_smtp_line_length_limit: false
+exim4_partial_smarthost_percentage: 0

--- a/readme.md
+++ b/readme.md
@@ -11,4 +11,5 @@ For smarthost clients:
 
 * exim4_smarthost smarthost domain.
 * exim4_use_client_certificates boolean, enable to generate client certificates.
-* exim4_configtype should be set to 'satellite' for clients.
+* exim4_configtype should be set to 'satellite' for clients or use the following:
+* exim4_partial_smarthost_percentage send only defined percentage of traffic to smarthost.

--- a/tasks/exim4.yml
+++ b/tasks/exim4.yml
@@ -40,6 +40,14 @@
   notify:
     - restart exim4
 
+- name: Copy smtp smarthost partial transport config
+  template:
+    src: 160_exim4-config_smarthost_partial.j2
+    dest: /etc/exim4/conf.d/router/160_exim4-config_smarthost_partial
+  when: exim4_partial_smarthost_percentage > 0
+  notify:
+    - restart exim4
+
 - name: Copy email-addresses
   template:
     src: email-addresses.j2

--- a/templates/160_exim4-config_smarthost_partial.j2
+++ b/templates/160_exim4-config_smarthost_partial.j2
@@ -1,0 +1,17 @@
+
+# Route only some messages to smarthost.
+# Used to send only part of traffic to smarthost
+# and rest normally on remote_smtp transport.
+# Use with dc_configtype = 'internet'.
+
+# This is copied from exim default smarthost router and condition is added to it.
+smarthost:
+  debug_print = "R: smarthost for $local_part@$domain"
+  condition = ${if <{${randint:100}}{ {{ exim4_partial_smarthost_percentage }} }}
+  driver = manualroute
+  domains = ! +local_domains
+  transport = remote_smtp_smarthost
+  route_list = * DCsmarthost byname
+  host_find_failed = ignore
+  same_domain_copy_routing = yes
+  no_more


### PR DESCRIPTION
This option allows sending only part of traffic to smarthost.
It can be used to slowly migrate traffic to smarthost.

Do not use satellite configuration with this option.