### PR TITLE
Replace deprecated squash_actions loop

### DIFF
--- a/tasks/remove_sendmail.yml
+++ b/tasks/remove_sendmail.yml
@@ -5,9 +5,10 @@
   ignore_errors: yes
 
 - name: Uninstall sendmail
-  apt: pkg={{ item }} state=absent
-  with_items:
-    - sendmail
-    - sendmail-base
-    - sendmail-bin
-    - sendmail-cf
+  apt:
+    state: absent
+    name:
+      - sendmail
+      - sendmail-base
+      - sendmail-bin
+      - sendmail-cf


### PR DESCRIPTION
The package list is now directly supplied to 'apt' module instead of
using a loop and relying on the implicit squash_actions feature.  The
deprecated method will be removed in Ansible 2.11.

More information:
https://docs.ansible.com/ansible/2.7/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions

The 'pkg' parameter is an alias for 'name'.
https://docs.ansible.com/ansible/2.7/modules/apt_module.html#parameters