### PR TITLE
Add newline to aliases template

### DIFF
--- a/templates/aliases.j2
+++ b/templates/aliases.j2
@@ -13,4 +13,5 @@ noc: root
 security: root
 root: {{exim4_root_email}}
 {% if exim4_aliases is defined %}{% for alias in exim4_aliases %}
-{{alias.name}}: {{alias.addresses|join(', ') }}{% endfor %}{% endif %}
+{{alias.name}}: {{alias.addresses|join(', ') }}
+{% endfor %}{% endif %}


### PR DESCRIPTION
This fixes cases where multiple aliases are defined. Earlier, multiple
aliases were printed on a single line, such as:

    alias1: address1alias2: address2

Adding a newline puts them to separate lines:

    alias1: address1
    alias2: address2

This may be related to Jinja2 configuration on whitespace control.