### PR TITLE
Selectively rewrite sender addresses

### DIFF
--- a/tasks/exim4.yml
+++ b/tasks/exim4.yml
@@ -48,6 +48,13 @@
   notify:
     - restart exim4
 
+- name: Copy sender address rewriting config
+  template:
+    src: 32_exim4-sender_rewriting.j2
+    dest: /etc/exim4/conf.d/rewrite/32_exim4-sender_rewriting
+  notify:
+    - restart exim4
+
 - name: Copy email-addresses
   template:
     src: email-addresses.j2

--- a/templates/32_exim4-sender_rewriting.j2
+++ b/templates/32_exim4-sender_rewriting.j2
@@ -1,0 +1,7 @@
+# Skip rewriting for the specified DKIM domains
+{% if exim4_dkim_domains is defined %}{% for domain in exim4_dkim_domains %}
+*@{{ domain }} * Fs
+{% endfor %}{% endif %}
+
+# Rewrite all other addresses with a 'bounces' address on the primary hostname
+*@* bounces@{{ exim4_primary_hostname }} Fs


### PR DESCRIPTION
The mail relay server used to pass through the return path for other
than mailing list mails. This meant that there should be an SPF record
corresponding to all of the return path addresses.

Instead, it was decided to rewrite the sender address so that the relay
server appears to be the sender. Rewriting is only done for
'envelope-from' (corresponding 'F' in exim4 configuration) and 'sender'
(s) fields.

The address rewriting is not done for the domains in exim4_dkim_domains,
but for all other addresses the sender address is rewritten to 'bounces'
on the primary hostname of the relay server.

This patch reuses exim4_dkim_domains since it was the same set of
domains that needed special handling for rewriting.

This patch was not tested with mailman yet since mailman was running on
another server during the setup. It may require further configuration.